### PR TITLE
Multiple changes

### DIFF
--- a/examples/flycheck_edt
+++ b/examples/flycheck_edt
@@ -10,4 +10,4 @@ EDT_HTTP_PORT=65000
 
 path=$1
 
-curl -s http://localhost:${EDT_HTTP_PORT}/flycheck\?path=$path
+curl -s http://localhost:${EDT_HTTP_PORT}/compile\?path=$path

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 {erl_opts, [debug_info]}.
-{deps, [cowboy, fs, unite]}.
+{deps, [cowboy, fs, unite, recon]}.
 
 {shell,
  [{config, "config/sys.config"},

--- a/src/edt.erl
+++ b/src/edt.erl
@@ -13,18 +13,20 @@
          get_env/2,
          includes/0]).
 
--export([auto_process/0,
-         http_port/0,
-         home/0,
-         ignore_regex/0,
+-export([
+         ct_groups/2,
          module_name/1,
          outdir/1,
-         relative_path/1,
-         source_path/1,
-         ct_groups/2,
          parse_path/1,
-         rebar3_profile/0]).
+         relative_path/1,
+         source_path/1]).
 
+-export([auto_process/0,
+         enable_http_server/0,
+         home/0,
+         http_port/0,
+         ignore_regex/0,
+         rebar3_profile/0]).
 %% Types
 -type compile_ret() :: {ok, {Path :: path(), module(), list()}}
                      | {error, {Errors ::list(),
@@ -119,6 +121,9 @@ auto_process() ->
 
 http_port() ->
     edt_lib:to_integer(edt:get_env(http_port, "65000")).
+
+enable_http_server() ->
+    edt_lib:to_boolean(edt:get_env(enable_http_server, "0")).
 
 
 %% ---------------------------------------------------------

--- a/src/edt_app.erl
+++ b/src/edt_app.erl
@@ -26,17 +26,20 @@ start(_StartType, _StartArgs) ->
                     ok
             end
     end,
-    init_cowboy(),
+    init_cowboy(edt:enable_http_server()),
     edt_sup:start_link().
 
 stop(_State) ->
     ok.
 
-init_cowboy() ->
+init_cowboy(Enable)
+  when Enable == true ->
     Dispatch = cowboy_router:compile(
-                 [{'_', [{"/flycheck", edt_http, #{}}]}]),
+                 [{'_', [{"/compile", edt_http, #{}}]}]),
     Port = edt:http_port(),
     {ok, _} = cowboy:start_clear(
                 edt_http_listener,
                 [{port, Port}],
-                #{env => #{dispatch => Dispatch}}).
+                #{env => #{dispatch => Dispatch}});
+init_cowboy(_) ->
+    ok.

--- a/src/edt_lib.erl
+++ b/src/edt_lib.erl
@@ -87,6 +87,10 @@ to_boolean(<<"true">>) ->
     true;
 to_boolean(1) ->
     true;
+to_boolean(true) ->
+    true;
+to_boolean("1") ->
+    true;
 to_boolean(_) ->
     false.
 
@@ -194,7 +198,9 @@ to_binary_test() ->
 to_boolean_test() ->
     true = to_boolean("true"),
     true = to_boolean(<<"true">>),
+    true = to_boolean("1"),
     true = to_boolean(1),
+    true = to_boolean(true),
     false = to_boolean(false),
     ok.
 

--- a/src/edt_sup.erl
+++ b/src/edt_sup.erl
@@ -22,7 +22,9 @@ init([]) ->
                   #{id => edt_post_action,
                     start => {edt_post_action, start_link, []}},
                   #{id => edt_out,
-                    start => {edt_out, start_link, []}}],
+                    start => {edt_out, start_link, []}},
+                  #{id => edt_trace,
+                    start => {edt_trace, start_link, []}}],
     {ok, {SupFlags, ChildSpecs}}.
 
 

--- a/src/edt_trace.erl
+++ b/src/edt_trace.erl
@@ -51,8 +51,7 @@ init([]) ->
     {ok, #{}}.
 
 handle_call({trace, {M, F}}, _From, State) ->
-    Reply = ok,
-    trace1(M, F),
+    Reply = trace1(M, F),
     {reply, Reply, State};
 handle_call({trace_result, {M, F}}, _From, State) ->
     Fun = fun({M1, F1, _}, _) ->

--- a/src/edt_trace.erl
+++ b/src/edt_trace.erl
@@ -1,0 +1,118 @@
+-module(edt_trace).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
+         start/0,
+         stop/0]).
+
+-export([trace/2,
+         trace_result/2]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2]).
+
+-define(SERVER, ?MODULE).
+
+%% ---------------------------------------------------------
+%% API
+%% ---------------------------------------------------------
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+start() ->
+    gen_server:start({local, ?SERVER}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:stop(?SERVER).
+
+%%
+%% @doc
+%%
+%% Trace M:F(...) and store the arguments and return value so that they can be retrieved
+%%
+%% @end
+%%
+trace(M, F) ->
+    gen_server:call(?SERVER, {trace, {M, F}}).
+
+trace_result(M, F) ->
+    gen_server:call(?SERVER, {trace_result, {M, F}}).
+
+%% ---------------------------------------------------------
+%% Gen server callbacks
+%% ---------------------------------------------------------
+init([]) ->
+    {ok, #{}}.
+
+handle_call({trace, {M, F}}, _From, State) ->
+    Reply = ok,
+    trace1(M, F),
+    {reply, Reply, State};
+handle_call({trace_result, {M, F}}, _From, State) ->
+    Fun = fun({M1, F1, _}, _) ->
+                  {M, F} == {M1, F1}
+          end,
+    Result1 = maps:filter(Fun, State),
+    Reply = latest_call(Result1),
+    {reply, Reply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info({call, {{M, F, Pid}, Args}}, State) ->
+    Now = erlang:system_time(seconds),
+    Key = {M, F, Pid},
+    Value = #{start_ts => Now,
+              args => Args},
+    Fun = fun(_) ->
+                  Value
+          end,
+    State1 = maps:update_with(Key, Fun, Value, State),
+    {noreply, State1};
+handle_info({return_from, {{M, F, Pid}, Result}}, State) ->
+    Now = erlang:system_time(seconds),
+    Key = {M, F, Pid},
+    Fun = fun(Value) ->
+                  Value#{end_ts => Now,
+                         result => Result}
+          end,
+    State1 = maps:update_with(Key, Fun, State),
+    {noreply, State1}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+%% ---------------------------------------------------------
+%% Internal functions
+%% ---------------------------------------------------------
+trace1(M, F) ->
+    Fun = fun_capture_args(self()),
+    Spec = {M, F, return_trace},
+    Opts = [{scope, local},
+            {formatter, Fun}],
+    recon_trace:calls(Spec, 10, Opts).
+
+fun_capture_args(Caller) ->
+    fun({trace, Pid, call, {M, F, Args}}) ->
+            Caller ! {call, {{M, F, Pid}, Args}},
+            ok;
+       ({trace, Pid, return_from, {M, F, _Arity}, Result}) ->
+            Caller ! {return_from, {{M, F, Pid}, Result}},
+            ok
+    end.
+
+latest_call(Result) when map_size(Result) == 0 ->
+    not_found;
+latest_call(Result) ->
+    Result1 = maps:values(Result),
+    Fun = fun(#{end_ts := E1}, #{end_ts := E2}) ->
+                  E2 =< E1
+          end,
+    [Result2|_] = lists:sort(Fun, Result1),
+    maps:with([args, result], Result2).

--- a/src/edt_trace.erl
+++ b/src/edt_trace.erl
@@ -8,6 +8,7 @@
          stop/0]).
 
 -export([trace/2,
+         trace/3,
          trace_result/2]).
 
 %% gen_server callbacks
@@ -39,7 +40,10 @@ stop() ->
 %% @end
 %%
 trace(M, F) ->
-    gen_server:call(?SERVER, {trace, {M, F}}).
+    gen_server:call(?SERVER, {trace, {M, F, '_'}}).
+
+trace(M, F, ArgsSpec) ->
+    gen_server:call(?SERVER, {trace, {M, F, ArgsSpec}}).
 
 trace_result(M, F) ->
     gen_server:call(?SERVER, {trace_result, {M, F}}).
@@ -50,8 +54,8 @@ trace_result(M, F) ->
 init([]) ->
     {ok, #{}}.
 
-handle_call({trace, {M, F}}, _From, State) ->
-    Reply = trace1(M, F),
+handle_call({trace, {M, F, ArgsSpec}}, _From, State) ->
+    Reply = trace1(M, F, ArgsSpec),
     {reply, Reply, State};
 handle_call({trace_result, {M, F}}, _From, State) ->
     Fun = fun({M1, F1, _}, _) ->
@@ -90,9 +94,9 @@ terminate(_Reason, _State) ->
 %% ---------------------------------------------------------
 %% Internal functions
 %% ---------------------------------------------------------
-trace1(M, F) ->
+trace1(M, F, ArgsSpec) ->
     Fun = fun_capture_args(self()),
-    Spec = {M, F, return_trace},
+    Spec = {M, F, [{ArgsSpec, [], [{return_trace}]}]},
     Opts = [{scope, local},
             {formatter, Fun}],
     recon_trace:calls(Spec, 10, Opts).

--- a/test/edt_app_SUITE.erl
+++ b/test/edt_app_SUITE.erl
@@ -55,7 +55,7 @@ test_invalid_parse_profile(_Config) ->
 test_valid_parse_profile(_Config) ->
     Children = supervisor:which_children(edt_sup),
     Ids = lists:sort([Id || {Id, _, _, _} <- Children]),
-    [edt_out, edt_post_action, edt_srv] = Ids,
+    [edt_out, edt_post_action, edt_srv, edt_trace] = Ids,
     ok.
 
 test_http(_Config) ->

--- a/test/edt_app_SUITE.erl
+++ b/test/edt_app_SUITE.erl
@@ -11,6 +11,7 @@ suite() ->
     [{timetrap, {seconds, 5}}].
 
 init_per_suite(Config) ->
+    application:set_env(edt, enable_http_server, true),
     Config.
 
 end_per_suite(_Config) ->
@@ -49,7 +50,7 @@ start_apps() ->
 test_invalid_parse_profile(_Config) ->
     Children = supervisor:which_children(edt_sup),
     Ids = lists:sort([Id || {Id, _, _, _} <- Children]),
-    [edt_out, edt_post_action, edt_srv] = Ids,
+    [edt_out, edt_post_action, edt_srv, edt_trace] = Ids,
     ok.
 
 test_valid_parse_profile(_Config) ->
@@ -59,10 +60,10 @@ test_valid_parse_profile(_Config) ->
     ok.
 
 test_http(_Config) ->
-    Result1 = httpc:request("http://localhost:65000/flycheck"),
+    Result1 = httpc:request("http://localhost:65000/compile"),
     {ok, {{"HTTP/1.1", 400, "Bad Request"}, _Headers1, _Body1}} = Result1,
 
-    Result2 = httpc:request("http://localhost:65000/flycheck?path=src/test_compile.erl"),
+    Result2 = httpc:request("http://localhost:65000/compile?path=src/test_compile.erl"),
     {ok, {{"HTTP/1.1", 200, "OK"}, _Headers2, Body2}} = Result2,
     "ERROR src/test_compile.erl \nsrc/test_compile.erl:none: Error: no such file or directory\n\n" = Body2,
     ok.

--- a/test/edt_trace_SUITE.erl
+++ b/test/edt_trace_SUITE.erl
@@ -1,0 +1,57 @@
+-module(edt_trace_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% ---------------------------------------------------------
+%% Common test callbacks
+%% ---------------------------------------------------------
+suite() ->
+    [{timetrap, {seconds, 5}}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    {ok, _} = edt_trace:start(),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    edt_trace:stop(),
+    ok.
+
+all() ->
+    [test_trace].
+
+test_trace(_Config) ->
+    edt_trace:trace(edt_trace_SUITE, trace_me),
+    not_found = edt_trace:trace_result(edt_trace_SUITE, trace_me),
+
+    Args1 = [test_trace, test1],
+    Result1 = edt_trace_SUITE:trace_me(test_trace, test1),
+    timer:sleep(100),
+    TraceResult1 = edt_trace:trace_result(edt_trace_SUITE, trace_me),
+    [args, result] =  lists:sort(maps:keys(TraceResult1)),
+    #{args := Args1} = TraceResult1,
+    #{result := Result1} = TraceResult1,
+
+    Args2 = [test_trace, test2],
+    Result2 = edt_trace_SUITE:trace_me(test_trace, test2),
+    timer:sleep(100),
+    TraceResult2 = edt_trace:trace_result(edt_trace_SUITE, trace_me),
+    [args, result] =  lists:sort(maps:keys(TraceResult2)),
+    #{args := Args2} = TraceResult2,
+    #{result := Result2} = TraceResult2,
+
+    ok.
+
+%% ---------------------------------------------------------
+%% Helper functions
+%% ---------------------------------------------------------
+
+trace_me(Arg1, Arg2) ->
+    {ok, {Arg1, Arg2}}.


### PR DESCRIPTION
### HTTP Server

Make starting http server optional. Not everyone will use the http compilation endpoint so enabling it by default will require configuring a different http port for each edt application instance.

### edt_trace

Module to trace and capture arguments and return value for a function call. I find myself often doing

```erlang
application:get_env(app, key, Value)
```

to capture a value while trying to understand code