### PR TITLE
Support the convent at AlertLogic where test location is configured

### DIFF
--- a/src/edt.erl
+++ b/src/edt.erl
@@ -149,6 +149,10 @@ parse_path(Path) ->
                 filename:join(lists:reverse(V))
         end,
     case Tokens of
+        [_ ,"src", "eunit", "test", App|Rest] ->
+            {ok, {test, App, FunPrefix(Rest)}};
+        [_ ,"src", "ct", "test", App|Rest] ->
+            {ok, {test, App, FunPrefix(Rest)}};
         [_, "src", App, "_checkouts"|Rest] ->
             {ok, {{src, checkouts}, App, FunPrefix(Rest)}};
         [_, "test", App, "_checkouts"|Rest] ->

--- a/test/edt_SUITE.erl
+++ b/test/edt_SUITE.erl
@@ -110,6 +110,15 @@ test_outdir(_Config) ->
     Path5 = "/Users/name/working/_checkouts/EDT_3/test/testing.erl",
     Expected5 = "_checkouts/EDT_3/test",
     Expected5 = edt:outdir(Path5),
+
+    Path6 = "/Users/name/working/EDT_3/test/eunit/src/Testing.erl",
+    Expected6 = "_build/default/lib/EDT_3/test",
+    Expected6 = edt:outdir(Path6),
+
+    Path7 = "/Users/name/working/EDT_3/test/ct/src/Testing.erl",
+    Expected7 = "_build/default/lib/EDT_3/test",
+    Expected7 = edt:outdir(Path7),
+
     ok.
 
 test_file_type(_Config) ->


### PR DESCRIPTION
- test/ct/src/
- test/eunit/src/

It's difficult to imagine why one would like to use configuration over contention and add tests at different locations, but let's make it easier for those projects as well.