### PR TITLE
Change signature of trace functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ available on ELPA with the following configuration.
 ```
 
 See [flycheck_edt](examples/flycheck_edt)
+
+# EDT Profile
+
+What is edt_profile, examples of how to use it.
+
+## Supported environment variables
+
+```bash
+EDT_PROFILE_TRACK_CALLS=true
+EDT_PROFILE_MAX_CALLS=1000
+EDT_PROFILE_CAPTURE=true
+```

--- a/src/edt.erl
+++ b/src/edt.erl
@@ -134,16 +134,16 @@ home() ->
     edt:get_env(home, Dir).
 
 ignore_regex() ->
-    edt_lib:to_binary(edt:get_env(ignore_regex, "")).
+    edt:get_env(ignore_regex, "").
 
 auto_process() ->
-    edt_lib:to_boolean(edt:get_env(auto_process, "true")).
+    edt:get_env(auto_process, "true").
 
 http_port() ->
-    edt_lib:to_integer(edt:get_env(http_port, "65000")).
+    edt:get_env(http_port, "65000").
 
 enable_http_server() ->
-    edt_lib:to_boolean(edt:get_env(enable_http_server, "0")).
+    edt:get_env(enable_http_server, "false").
 
 %% ---------------------------------------------------------
 %% Internal Functions
@@ -281,7 +281,8 @@ ct_groups(Module, Case) ->
 -spec get_env(Key :: atom(), Default :: any()) -> any().
 get_env(Key, Default) when is_atom(Key) ->
     Default1 = os:getenv(to_osenv_var(Key), Default),
-    application:get_env(edt, Key, Default1).
+    Value = application:get_env(edt, Key, Default1),
+    maybe_convert(Key, Value).
 
 get_env(Key) ->
     get_env(Key, undefined).
@@ -294,3 +295,20 @@ set_env(Key, Value) ->
 to_osenv_var(Key) ->
     Key1 = atom_to_list(Key),
     "EDT_" ++ string:uppercase(Key1).
+
+maybe_convert(profile_track_calls, Value) ->
+    edt_lib:to_boolean(Value);
+maybe_convert(profile_capture, Value) ->
+    edt_lib:to_boolean(Value);
+maybe_convert(profile_max_calls, Value) ->
+    edt_lib:to_integer(Value);
+maybe_convert(auto_process, Value) ->
+    edt_lib:to_boolean(Value);
+maybe_convert(http_port, Value) ->
+    edt_lib:to_integer(Value);
+maybe_convert(enable_http_server, Value) ->
+    edt_lib:to_boolean(Value);
+maybe_convert(ignore_regex, Value) ->
+    edt_lib:to_binary(Value);
+maybe_convert(_, Value) ->
+    Value.

--- a/src/edt.erl
+++ b/src/edt.erl
@@ -246,8 +246,15 @@ ct(Module, TestCase, Opts) ->
             [{suite, Module} || Module /= undefined] ++
             [{testcase, TestCase} || TestCase /= undefined],
     Opts2 = Opts1 ++ Opts,
+    Opts3 =
+        case filelib:is_file("cover.spec") of
+            true ->
+                Opts2 ++ [{cover, "./cover.spec"}];
+            false ->
+                Opts2
+        end,
     filelib:ensure_dir(LogDir),
-    ct:run_test(Opts2).
+    ct:run_test(Opts3).
 
 ct_groups(Module, Case) ->
     Group =

--- a/src/edt.erl
+++ b/src/edt.erl
@@ -16,6 +16,7 @@
     file_type/1,
     get_env/1,
     get_env/2,
+    set_env/2,
     includes/0
 ]).
 
@@ -284,6 +285,10 @@ get_env(Key, Default) when is_atom(Key) ->
 
 get_env(Key) ->
     get_env(Key, undefined).
+
+-spec set_env(Key :: atom(), Value :: any()) -> any().
+set_env(Key, Value) ->
+    application:set_env(edt, Key, Value).
 
 %% internal functions
 to_osenv_var(Key) ->

--- a/src/edt.erl
+++ b/src/edt.erl
@@ -98,7 +98,7 @@ compile_opts(Path) ->
     [export_all, debug_info, {d, 'TEST'}, return] ++ Includes ++ OutDir.
 
 eunit_opts() ->
-    [no_tty, {report, {unite_compact, [profile]}}].
+    [].
 
 includes() ->
     Home = home(),

--- a/src/edt_api.erl
+++ b/src/edt_api.erl
@@ -2,10 +2,11 @@
 %% Copyright 2020 Raghav Karol.
 %%
 -module(edt_api).
-
 -export([
     compile/1,
-    test/1, test/2, test/3
+    test/1,
+    test/2,
+    test/3
 ]).
 %% ---------------------------------------------------------
 %% API

--- a/src/edt_app.erl
+++ b/src/edt_app.erl
@@ -45,7 +45,7 @@ start_cowboy(true) ->
         [{'_', [{'_', edt_http, #{}}]}]
     ),
     Port = edt:http_port(),
-    {ok, Ref} = cowboy:start_clear(
+    {ok, _Ref} = cowboy:start_clear(
         edt_http_listener,
         [{port, Port}],
         #{env => #{dispatch => Dispatch}}

--- a/src/edt_app.erl
+++ b/src/edt_app.erl
@@ -33,21 +33,29 @@ start(_StartType, _StartArgs) ->
                     ok
             end
     end,
-    init_cowboy(edt:enable_http_server()),
+    start_cowboy(edt:enable_http_server()),
     edt_sup:start_link().
 
 stop(_State) ->
+    stop_cowboy(edt:enable_http_server()),
     ok.
 
-init_cowboy(true) ->
+start_cowboy(true) ->
     Dispatch = cowboy_router:compile(
         [{'_', [{'_', edt_http, #{}}]}]
     ),
     Port = edt:http_port(),
-    {ok, _} = cowboy:start_clear(
+    {ok, Ref} = cowboy:start_clear(
         edt_http_listener,
         [{port, Port}],
         #{env => #{dispatch => Dispatch}}
-    );
-init_cowboy(_) ->
+    ),
+    ok;
+start_cowboy(_) ->
+    ok.
+
+stop_cowboy(true) ->
+    cowboy:stop_listener(edt_http_listener),
+    ok;
+stop_cowboy(_) ->
     ok.

--- a/src/edt_http.erl
+++ b/src/edt_http.erl
@@ -103,6 +103,6 @@ handle(#{path := <<"/edt/trace">>} = Req) ->
         function := Func
     } = cowboy_req:match_qs([module, function], Req),
     Opts = #{track_calls => true, max_calls => 10},
-    Specs = [{edt_lib:to_atom(Module), edt_lib:to_atom(Func), #{capture => true}}],
+    Specs = [{edt_lib:to_atom(Module), edt_lib:to_atom(Func), '_', #{capture => true}}],
     Result = edt_profile:trace_opts(Specs, Opts),
     edt_lib:to_binary(Result).

--- a/src/edt_post_action.erl
+++ b/src/edt_post_action.erl
@@ -13,6 +13,7 @@
 ]).
 
 -export([
+    add/1,
     add/2,
     delete/1,
     list/0
@@ -107,6 +108,12 @@ add(Name, {Mod, Fun, Args} = MFArgs) when
     is_list(Args)
 ->
     gen_server:call(?SERVER, {add, {Name, MFArgs}}).
+
+%% @doc Add a post action called 'test' that runs tests in the given module
+%%
+%% see {@link add/2}
+add({test, Module}) ->
+    add(test, fun() -> edt_api:test(Module) end).
 
 delete(Name) when is_atom(Name) ->
     gen_server:call(?SERVER, {delete, Name}).

--- a/src/edt_profile.erl
+++ b/src/edt_profile.erl
@@ -163,7 +163,7 @@ handle_info({return_from, {Pid, M, F, Arity, Result, EndTime, EndReds}}, State) 
     maybe_track_exceptions(State, Pid, ExCalls),
     %% TODO: summary for exception calls as well?
 
-    % Store aggregatee results accross pids
+    % Store aggregate results accros pids
     edt_profile_store:track_summary(ContextId, Pid, Call, Arity, EndTime, EndReds),
     {noreply, State2}.
 

--- a/src/edt_profile.erl
+++ b/src/edt_profile.erl
@@ -74,7 +74,7 @@ stop() ->
 trace(M) when is_atom(M) ->
     trace(M, '_');
 trace(Specs) when is_list(Specs) ->
-    TOpts = default_trace_opts(),
+    TOpts = default_opts(topts),
     trace_opts(Specs, TOpts).
 
 trace(M, F) ->
@@ -115,7 +115,7 @@ trace(M, F, ArgSpec, FOpts) ->
 %% can be related to the parent.
 %%
 trace_opts(Specs, TOpts) ->
-    TOpts1 = maps:merge(default_trace_opts(), TOpts),
+    TOpts1 = maps:merge(default_opts(topts), TOpts),
     Specs1 = lists:map(fun to_trace_spec/1, Specs),
     gen_server:call(?SERVER, {trace, Specs1, TOpts1}).
 
@@ -172,15 +172,14 @@ terminate(_Reason, _State) ->
 %% ---------------------------------------------------------
 %% Internal functions
 %% ---------------------------------------------------------
-default_trace_opts() ->
+default_opts(topts) ->
     Track = edt:get_env(profile_track_calls, false),
     Max = edt:get_env(profile_max_calls, 100),
     #{
         track_calls => Track,
         max_calls => Max
-    }.
-
-default_trace_fopts() ->
+    };
+default_opts(fopts) ->
     Capture = edt:get_env(profile_capture, false),
     StartContext = edt:get_env(profile_start_context, false),
     #{
@@ -355,10 +354,10 @@ maybe_stop_context(Pid, M, F, State) ->
 to_trace_spec(M) when is_atom(M) ->
     to_trace_spec({M, '_'});
 to_trace_spec({M, F}) ->
-    FOpts = default_trace_fopts(),
+    FOpts = default_opts(fopts),
     to_trace_spec({M, F, '_', FOpts});
 to_trace_spec({M, F, FOpts}) ->
-    FOpts1 = maps:merge(default_trace_fopts(), FOpts),
+    FOpts1 = maps:merge(default_opts(fopts), FOpts),
     to_trace_spec({M, F, FOpts1, '_'});
 to_trace_spec({_, _, _, _} = Spec) ->
     Spec.
@@ -386,7 +385,7 @@ maybe_capture_result(_, _) ->
     '$not_captured'.
 
 fopts(M, F, Opts) ->
-    Default = default_trace_fopts(),
+    Default = default_opts(fopts),
     Map1 = maps:get({M, '_'}, Opts, Default),
     maps:get({M, F}, Opts, Map1).
 

--- a/src/edt_profile_pprint.erl
+++ b/src/edt_profile_pprint.erl
@@ -92,7 +92,7 @@ header(Fields, #srec{}) ->
         {context_id, {10, "context_id"}},
         {pid, {15, "pid"}},
         {count, {10, "count"}},
-        {time, {10, "time"}},
+        {time, {10, "time (us)"}},
         {reductions, {15, "reductions"}}
     ],
     case Fields of
@@ -106,7 +106,7 @@ header(Fields, #crec{}) ->
         {seq_num, {10, "seq_num"}},
         {id, {10, "id"}},
         {pid, {15, "pid"}},
-        {time, {10, "time"}},
+        {time, {10, "time (us)"}},
         {reductions, {15, "reductions"}},
         {return, {10, "return"}}
     ],

--- a/test/edt_profile_SUITE.erl
+++ b/test/edt_profile_SUITE.erl
@@ -42,7 +42,7 @@ test_trace1_without_opts(_Config) ->
     ok.
 
 test_trace1_with_opts(_Config) ->
-    edt_profile:trace([{edt_profile_SUITE, one, #{capture => true, start_context => true}}]),
+    edt_profile:trace([{edt_profile_SUITE, one, '_', #{capture => true, start_context => true}}]),
     one(),
     timer:sleep(100),
     edt_profile_pprint:summary(),
@@ -56,14 +56,14 @@ test_trace2(_Config) ->
     ok.
 
 test_trace3(_Config) ->
-    edt_profile:trace(edt_profile_SUITE, one, #{capture => true, start_context => true}),
+    edt_profile:trace(edt_profile_SUITE, one, '_', #{capture => true, start_context => true}),
     one(),
     timer:sleep(100),
     edt_profile_pprint:summary(),
     ok.
 
 test_trace4(_Config) ->
-    edt_profile:trace(edt_profile_SUITE, one, #{capture => true, start_context => true}, '_'),
+    edt_profile:trace(edt_profile_SUITE, one, '_', #{capture => true, start_context => true}),
     one(),
     timer:sleep(100),
     edt_profile_pprint:summary(),
@@ -94,7 +94,7 @@ test_call_graph(_Config) ->
     ok.
 
 test_capture(_Config) ->
-    Specs = [{edt_profile_SUITE, one, #{capture => true}}],
+    Specs = [{edt_profile_SUITE, one, '_', #{capture => true}}],
     Opts = #{track_calls => true, max_calls => 10},
     edt_profile:trace_opts(Specs, Opts),
     one(),


### PR DESCRIPTION
### Description 

Update order of arguments for trace functions from `{Module, Function, Opts, ArgSpec}`  to`{Module, Function, ArgSpec, Opts}` as the latter is more consistent with the erlang idiom of `{M, F, A}`

